### PR TITLE
Fixes #177 

### DIFF
--- a/app/lib/components/noteElements/videoComponent.tsx
+++ b/app/lib/components/noteElements/videoComponent.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from "react"; //what if i just delete this file lol 
 import { VideoType } from "../../models/media_class";
 import { UploadIcon, VideoIcon } from "lucide-react";
 import {


### PR DESCRIPTION
Reference:
Fixes #177 

What changed?
All of the media buttons were combined into one "upload media" button. This includes video, audio, and images, now all as one singular button. Since all of the media buttons were combined, the initial video button at the top of the tool bar was removed. 

Why it was changed?
The audio and video upload buttons were placed far apart from the image upload button. This was confusing to users because file uploads should be together and not separate. 

How it was changed?
In the front end, videoComponent is the file that controls the button that exists initially. This was removed. 
The logic for the button was coded into editor_menu_controls and note_toolbar.
In the backend, the logic was updated to include all supported video filetypes to ensure compatibility.

