### PR TITLE
Fixes 181 

### DIFF
--- a/app/lib/pages/aboutPage/page.tsx
+++ b/app/lib/pages/aboutPage/page.tsx
@@ -263,8 +263,9 @@ const Page = () => {
                     </a>
                 </div>
             </div>
-          {/* Amy Chen */}
-          <div className="flex flex-col items-center hover:scale-110 transition-transform duration-300">
+
+            {/* Amy Chen */}
+            <div className="flex flex-col items-center hover:scale-110 transition-transform duration-300">
                 <div className="overflow-hidden rounded-full w-32 h-32"> {/* Container for circular crop */}
                     <Image
                       src="/aboutPageImages/Amy.jpg"
@@ -285,6 +286,35 @@ const Page = () => {
                     </a>
                     {/* LinkedIn Icon */}
                     <a href="https://www.linkedin.com/in/amy-chen-0a1232258/" target="_blank" rel="noopener noreferrer">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 448 512">
+                            <path d="M100.28 448H7.4V148.9h92.88zm-46.1-329.72a53.62 53.62 0 11-53.62-53.62 53.62 53.62 0 0153.61 53.61zM447.9 448h-92.68V305.69c0-33.89-12.13-57.08-42.35-57.08-23.11 0-36.86 15.55-42.91 30.59-2.2 5.39-2.74 12.9-2.74 20.48V448H174.69s1.24-269 0-297h92.68v42.06a91 91 0 0183.26-45.84c60.84 0 106.38 39.68 106.38 124.86z"/>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
+            {/* Justin Wang */}
+              <div className="flex flex-col items-center hover:scale-110 transition-transform duration-300">
+                <div className="overflow-hidden rounded-full w-32 h-32"> {/* Container for circular crop */}
+                    <Image
+                      src="/aboutPageImages/Justin.jpg"
+                      alt="Justin Wang"
+                      width={128}
+                      height={128}
+                      className="object-cover" // Ensures the image fills the container
+                    />
+                </div>
+                <p className="mt-4 font-semibold text-center">Justin Wang</p>
+                <p className="font-semibold text-center">Developer</p>
+                <div className="flex mt-2 space-x-4">
+                    {/* GitHub Icon */}
+                    <a href="https://github.com/jwang-101" target="_blank" rel="noopener noreferrer">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 496 512">
+                            <path d="M248 8C111 8 0 119 0 256c0 110.3 71.3 203.9 170.5 237.2 12.5 2.3 17.1-5.4 17.1-12v-42.3c-69.4 15.1-83.8-33.6-83.8-33.6-11.4-28.9-27.8-36.6-27.8-36.6-22.7-15.5 1.7-15.2 1.7-15.2 25.1 1.8 38.3 25.8 38.3 25.8 22.3 38.2 58.5 27.2 72.8 20.8 2.2-16.1 8.7-27.2 15.8-33.5-55.4-6.3-113.6-27.7-113.6-123.2 0-27.2 9.7-49.4 25.6-66.8-2.6-6.3-11.1-31.8 2.5-66.2 0 0 21-6.7 68.7 25.6a237.1 237.1 0 01125.2 0c47.6-32.3 68.6-25.6 68.6-25.6 13.7 34.4 5.2 59.9 2.6 66.2 16 17.4 25.6 39.6 25.6 66.8 0 95.7-58.4 116.8-113.9 123 8.9 7.7 16.8 22.9 16.8 46.2v68.4c0 6.7 4.6 14.3 17.2 11.9C424.8 459.9 496 366.3 496 256 496 119 385 8 248 8z"/>
+                        </svg>
+                    </a>
+                    {/* LinkedIn Icon */}
+                    <a href="https://www.linkedin.com/in/justin-wang-2a67b1295/" target="_blank" rel="noopener noreferrer">
                         <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24" viewBox="0 0 448 512">
                             <path d="M100.28 448H7.4V148.9h92.88zm-46.1-329.72a53.62 53.62 0 11-53.62-53.62 53.62 53.62 0 0153.61 53.61zM447.9 448h-92.68V305.69c0-33.89-12.13-57.08-42.35-57.08-23.11 0-36.86 15.55-42.91 30.59-2.2 5.39-2.74 12.9-2.74 20.48V448H174.69s1.24-269 0-297h92.68v42.06a91 91 0 0183.26-45.84c60.84 0 106.38 39.68 106.38 124.86z"/>
                         </svg>


### PR DESCRIPTION
Reference: 
Fixes #181 

What was changed:
I added a picture of myself to the photos for the about page. I also linked my github and linkedin.

Why it was changed:
It was requested by the client that us capstone students should ad ourselves to the about page as developers, to credit us for the work we've done so far.

How it was changed
Css was added for my name, developer role, image, and the linkedin and github links in the about page, with the proper hyperlink when the user clicks the icons. 
