### PR TITLE
Simple fix for note view upon page load bug

### DIFF
--- a/app/lib/components/side_bar.tsx
+++ b/app/lib/components/side_bar.tsx
@@ -95,7 +95,7 @@ const Sidebar: React.FC<SidebarProps> = ({ onNoteSelect }) => {
           const convertedNotes = DataConversion.convertMediaTypes(userNotes).reverse();
 
           const unarchivedNotes = convertedNotes.filter((note) => !note.isArchived); //filter out archived notes
-          const publishedNotes = convertedNotes.filter((note) => note.published); //filter out archived notes
+          const publishedNotes = convertedNotes.filter((note) => note.published); //filter out unpublished notes
 
           setNotes(unarchivedNotes);
           setFilteredNotes(publishedNotes);

--- a/app/lib/components/side_bar.tsx
+++ b/app/lib/components/side_bar.tsx
@@ -95,9 +95,10 @@ const Sidebar: React.FC<SidebarProps> = ({ onNoteSelect }) => {
           const convertedNotes = DataConversion.convertMediaTypes(userNotes).reverse();
 
           const unarchivedNotes = convertedNotes.filter((note) => !note.isArchived); //filter out archived notes
+          const publishedNotes = convertedNotes.filter((note) => note.published); //filter out archived notes
 
           setNotes(unarchivedNotes);
-          setFilteredNotes(unarchivedNotes);
+          setFilteredNotes(publishedNotes);
         } else {
           console.error("User not logged in");
         }

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
Fixes #197 

The subset of notes shown when the Notes page is loaded is now specifically set to Published.

Previously, all notes would show when the page was loaded due to the filtering initially being set to notes that were not archived. Now, the notes shown matches the initial position of the note view slider, albeit independently of each other.

A rule has been added where user messages are loaded around line 90 in side_bar.tsx to get only the set of published notes, used only to show this subset rather than all notes that are not archived when the page is first loaded. The initial position of the note view slider is set separately, though behavior is as intended as the set of displayed notes is further handled by the slider itself after this.