### PR TITLE
Require first and last name input upon registration

### DIFF
--- a/app/__tests__/register_button.test.tsx
+++ b/app/__tests__/register_button.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import RegisterButton from "../lib/components/register_button"; 
+import { validateEmail, validateFirstName, validateLastName } from '../lib/utils/validation';
 
 test('Register button is clickable when not in a loading state', () => {
   const { getByText } = render(<RegisterButton />);
@@ -10,6 +11,16 @@ test('Register button is clickable when not in a loading state', () => {
   // You can add assertions here to test the button's behavior when clicked
 });
 
+test('Validation functions for E-mail, first and last name are valid with input and invalid when empty', () => {
+  expect(validateEmail('mail@example.com')).toBeTruthy(); //These should probably be changed to test input on the register button itself.
+  expect(validateEmail('')).toBeFalsy();
+
+  expect(validateFirstName('firstName')).toBeTruthy();
+  expect(validateFirstName('')).toBeFalsy();
+
+  expect(validateLastName('lastName')).toBeTruthy();
+  expect(validateLastName('')).toBeFalsy();
+});
 
 test('Register button is disabled when in a loading state', () => {
     const { getByText } = render(<RegisterButton />);

--- a/app/lib/pages/signupPage/page.tsx
+++ b/app/lib/pages/signupPage/page.tsx
@@ -5,7 +5,7 @@ import RegisterButton from "../../components/register_button";
 import { toast } from "sonner";
 import { auth, db } from "../../config/firebase"; // Ensure you import Firestore as well
 import { createUserWithEmailAndPassword } from "firebase/auth";
-import { validateEmail, validatePassword } from "../../utils/validation";
+import { validateEmail, validatePassword, validateFirstName, validateLastName } from "../../utils/validation";
 import { User } from "../../models/user_class";
 import ApiService from "../../utils/api_service";
 import { Timestamp, doc, setDoc } from "firebase/firestore";
@@ -27,6 +27,9 @@ const SignupPage = () => {
       toast.error("Passwords do not match");
       return;
     }
+
+    if (!validateFirstName(firstName)) return;
+    if (!validateLastName(lastName)) return;
 
     try {
       // Create the user in Firebase Authentication

--- a/app/lib/utils/validation.js
+++ b/app/lib/utils/validation.js
@@ -17,3 +17,21 @@ export const validatePassword = (password) => {
   // Add more password validations as needed
   return true;
 };
+
+
+//Only checks if there is at least one character in each field. Can be changed in the future.
+export const validateFirstName = (firstName) => {
+  if (firstName.length == 0) {
+    toast.error("Must provide a first name");
+    return false;
+  }
+  return true;
+};
+
+export const validateLastName = (lastName) => {
+  if (lastName.length == 0) {
+    toast.error("Must provide a last name");
+    return false;
+  }
+  return true;
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
Fixes #205

The first and last name input fields on the registration page are now required to be completed in order for the form to be submitted.

An oversight which allows new users to register without entering a first or last name was identified previously. This change makes it so that these fields cannot be left empty, bringing the desktop version of this project in line with the mobile app.

Simple validation functions have been added to validation.js for the first and last name variables in the signupPage's page.tsx file, making it so that the registration request cannot be sent from the client if these fields are left empty. A message prompts the user in the same way as for an invalid E-mail or password in this case. These functions, along with the existing validations for the E-mail and password, can be changed in the future to use more strict rules for the input provided by users.

![firstNameMessage](https://github.com/user-attachments/assets/6b75229c-7fcf-4b6b-9f88-8357c4e47124)
![lastNameMessage](https://github.com/user-attachments/assets/494a4051-0f2d-4087-9d0a-cb504f7bd595)