### PR TITLE
Video Upload MP4 Conversion Functionality

### DIFF
--- a/app/lib/components/noteElements/note_component.tsx
+++ b/app/lib/components/noteElements/note_component.tsx
@@ -16,6 +16,7 @@ import useExtensions from "../../utils/use_extensions";
 import { User } from "../../models/user_class";
 import { Document, Packer, Paragraph } from "docx"; // For DOCX
 import jsPDF from "jspdf"; // For PDF
+import { FFmpeg } from '@ffmpeg/ffmpeg'; // For Video
 import ApiService from "../../utils/api_service";
 import { FileX2, SaveIcon, Calendar, MapPin, Music } from "lucide-react";
 import {
@@ -478,6 +479,14 @@ export default function NoteEditor({
     });
   };
 
+  const convertVideo = (videoUrl: string) => {
+    const editor = rteRef.current?.editor;
+    if (editor) {
+      editor
+      //Unsure where the conversion functionality should be implemented.
+    }
+  };
+
   const [isAudioModalOpen, setIsAudioModalOpen] = React.useState(false);
 
   const fetchSuggestedTags = async () => {
@@ -706,7 +715,7 @@ export default function NoteEditor({
                           type: "image",
                         }),
                       ]);
-                    } else if (media.type === "video") {
+                    } else if (media.type === "video") { //Where is this functionality used in the note editor?
                       const newVideo = new VideoType({
                         uuid: uuidv4(),
                         uri: media.uri,
@@ -714,6 +723,7 @@ export default function NoteEditor({
                         thumbnail: "",
                         duration: "0:00",
                       });
+                      //Still determining where the filtering for mp4 files only occurs in the upload process.
               
                       noteHandlers.setVideos((prevVideos) => [...prevVideos, newVideo]);
               

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/preset-typescript": "^7.23.0",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@ffmpeg/ffmpeg": "^0.12.15",
     "@googlemaps/js-api-loader": "^1.16.6",
     "@googlemaps/markerclusterer": "^2.5.3",
     "@jest/globals": "^29.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.2.22)(react@18.3.1))(@types/react@18.2.22)(react@18.3.1)
+      '@ffmpeg/ffmpeg':
+        specifier: ^0.12.15
+        version: 0.12.15
       '@googlemaps/js-api-loader':
         specifier: ^1.16.6
         version: 1.16.8
@@ -1401,6 +1404,14 @@ packages:
 
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
+
+  '@ffmpeg/ffmpeg@0.12.15':
+    resolution: {integrity: sha512-1C8Obr4GsN3xw+/1Ww6PFM84wSQAGsdoTuTWPOj2OizsRDLT4CXTaVjPhkw6ARyDus1B9X/L2LiXHqYYsGnRFw==}
+    engines: {node: '>=18.x'}
+
+  '@ffmpeg/types@0.12.4':
+    resolution: {integrity: sha512-k9vJQNBGTxE5AhYDtOYR5rO5fKsspbg51gbcwtbkw2lCdoIILzklulcjJfIDwrtn7XhDeF2M+THwJ2FGrLeV6A==}
+    engines: {node: '>=16.x'}
 
   '@firebase/analytics-compat@0.2.14':
     resolution: {integrity: sha512-unRVY6SvRqfNFIAA/kwl4vK+lvQAL2HVcgu9zTrUtTyYDmtIt/lOuHJynBMYEgLnKm39YKBDhtqdapP2e++ASw==}
@@ -7581,6 +7592,12 @@ snapshots:
   '@emotion/utils@1.4.2': {}
 
   '@emotion/weak-memoize@0.4.0': {}
+
+  '@ffmpeg/ffmpeg@0.12.15':
+    dependencies:
+      '@ffmpeg/types': 0.12.4
+
+  '@ffmpeg/types@0.12.4': {}
 
   '@firebase/analytics-compat@0.2.14(@firebase/app-compat@0.2.43)(@firebase/app@0.10.13)':
     dependencies:


### PR DESCRIPTION
Will fix #214

Adding functionality to convert any uploaded video files to .mp4 format for use within notes.

Automatic conversion of files within the project will improve user convenience, and no external software or time spent converting will be required to upload videos to notes.

I am using the FFmpeg package in order to convert video files upon upload to the Notes editor. Currently, I am still locating the functionality for this as the media button does not appear on the current version of the page. The conversion will be handled either in note_component.tsx or note_handler.ts, depending on what is required.