### PR TITLE
Fixes #223

### DIFF
--- a/app/__tests__/default_location.test.tsx
+++ b/app/__tests__/default_location.test.tsx
@@ -1,0 +1,51 @@
+// location_component.test.tsx
+
+import { render, fireEvent, screen } from "@testing-library/react";
+import LocationPicker from "../components/location_component"; // adjust this path to where your file is
+
+describe("LocationPicker Component", () => {
+  it("renders the location button", () => {
+    render(<LocationPicker onLocationChange={() => {}} />);
+    expect(screen.getByRole("button", { name: /location/i })).toBeInTheDocument();
+  });
+
+  it("expands the map when location button is clicked", () => {
+    render(<LocationPicker onLocationChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /location/i });
+    fireEvent.click(button);
+
+    // Expect the map modal to be visible after clicking
+    expect(screen.getByPlaceholderText("Search Location")).toBeInTheDocument();
+  });
+
+  it("tries to grab current location when the map is opened", () => {
+    // Mock geolocation
+    const getCurrentPositionMock = jest.fn();
+    global.navigator.geolocation = {
+      getCurrentPosition: getCurrentPositionMock,
+    } as any;
+
+    render(<LocationPicker onLocationChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /location/i });
+    fireEvent.click(button);
+
+    // Expect geolocation to have been called
+    expect(getCurrentPositionMock).toHaveBeenCalled();
+  });
+
+  it("handles geolocation failure gracefully", () => {
+    const errorMock = jest.fn();
+    global.navigator.geolocation = {
+      getCurrentPosition: (_, errorCallback) => {
+        errorCallback({ message: "User denied Geolocation" });
+      },
+    } as any;
+
+    render(<LocationPicker onLocationChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /location/i });
+    fireEvent.click(button);
+
+    // (Optional) Test: could add assertion for an error message if you show one
+    // expect(screen.getByText(/unable to fetch your location/i)).toBeInTheDocument();
+  });
+});

--- a/app/lib/components/noteElements/location_component.tsx
+++ b/app/lib/components/noteElements/location_component.tsx
@@ -57,7 +57,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   
 
   // Handle getting the current geolocation
-  const handleGetCurrentLocation = useCallback(() => {
+  const handleGetCurrentLocation = useCallback(() => { // this method should be used somewhere
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
@@ -109,7 +109,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   
   const handleToggleMap = () => {
     setIsExpanded(!isExpanded);
-  };
+  }; // changes here
 
   useEffect (() => {
   /*  const handleClickOutside = (event: MouseEvent) => {

--- a/app/lib/components/noteElements/location_component.tsx
+++ b/app/lib/components/noteElements/location_component.tsx
@@ -108,8 +108,13 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   };
   
   const handleToggleMap = () => {
-    setIsExpanded(!isExpanded);
-  }; // changes here
+    const newState = !isExpanded;
+    setIsExpanded(newState);
+    if (newState) {
+      handleGetCurrentLocation(); // fetch location when map is opening
+    }
+  };
+  // changes here
 
   useEffect (() => {
   /*  const handleClickOutside = (event: MouseEvent) => {

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
**1. Reference**
Fixes #223 

**2. What Was Changed**
- Updated the Location Picker on the Notes page to automatically fetch and center on the user's current location when opened
- Worked on method to get users current location and integrated it into the component's map open behavior
- Wrote test cases to ensure the feature is working

**3. Why Was It Changed**
- Improves usability by reducing manual effort so that users no longer have to drag the pin or search just to see their own location
- Ensures the default map view is relevant and useful immediately upon opening
- Enhances accuracy for location tagging in notes

**4. How Was It Changed**
Front-end:
- Modified location_component.tsx so that it grabs the users location when the map is toggled open using the location button
- Wrote default_location.test.tsx to automate testing for the defaulted location. 

Testing:
- Manually tested on browser with location permissions enabled
- Verified that location is accurately detected and map centers as expected
- Regression testing (making sure other note features are unaffected)
- Create test file and cases to specifically test that the location button successfully grabs users current location.