### PR TITLE
Fixes #156

### DIFF
--- a/app/__tests__/batchLoad.test.tsx
+++ b/app/__tests__/batchLoad.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+// A simple self-contained batching component to test
+function MockBatchedNoteList({ notes }: { notes: any[] }) {
+  const [visibleCount, setVisibleCount] = React.useState(15);
+  const visibleNotes = notes.slice(0, visibleCount);
+  const canLoadMore = visibleCount < notes.length;
+
+  return (
+    <div>
+      {visibleNotes.map((note) => (
+        <div key={note.id} data-testid="note">{note.title}</div>
+      ))}
+      {canLoadMore && (
+        <button onClick={() => setVisibleCount(visibleCount + 15)}>
+          Load More
+        </button>
+      )}
+    </div>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('MockBatchedNoteList batching with batch size 15', () => {
+  const generateMockNotes = (count: number) =>
+    Array.from({ length: count }, (_, i) => ({
+      id: `note-${i}`,
+      title: `Note ${i}`,
+    }));
+
+  it('shows only the first 15 notes initially', () => {
+    const notes = generateMockNotes(40);
+    render(<MockBatchedNoteList notes={notes} />);
+    expect(screen.getAllByTestId('note')).toHaveLength(15);
+  });
+
+  it('loads 15 more notes when "Load More" is clicked', () => {
+    const notes = generateMockNotes(40);
+    render(<MockBatchedNoteList notes={notes} />);
+    fireEvent.click(screen.getByText(/load more/i));
+    expect(screen.getAllByTestId('note')).toHaveLength(30);
+  });
+
+  it('hides the "Load More" button when all notes are shown', () => {
+    const notes = generateMockNotes(30);
+    render(<MockBatchedNoteList notes={notes} />);
+    fireEvent.click(screen.getByText(/load more/i));
+    expect(screen.queryByText(/load more/i)).toBeNull();
+    expect(screen.getAllByTestId('note')).toHaveLength(30);
+  });
+});

--- a/app/lib/components/note_listview.tsx
+++ b/app/lib/components/note_listview.tsx
@@ -13,12 +13,15 @@ const extractTextFromHtml = (htmlString: string) => {
   return tempDivElement.textContent || tempDivElement.innerText || "";
 };
 
+const BATCH_SIZE = 15;
+
 const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [fresh, setFresh] = useState(true);
+  const [batchCount, setBatchCount] = useState(1);
 
-  const visibleNotes = notes.filter(note => !note.isArchived); //filter out archived notes
-  
+  const visibleNotes = notes.filter(note => !note.isArchived);
+  const notesToRender = visibleNotes.slice(0, BATCH_SIZE * batchCount);
 
   useEffect(() => {
     if (visibleNotes.length > 0 && fresh) {
@@ -52,9 +55,9 @@ const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
 
   return (
     <div id="notes-list" className="my-4 flex flex-col">
-      {visibleNotes.map((note) => {
+      {notesToRender.map((note) => {
         const noteTextContent = extractTextFromHtml(note.text);
-  
+
         return (
           <div
             key={note.id}
@@ -77,8 +80,17 @@ const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
           </div>
         );
       })}
+
+      {notesToRender.length < visibleNotes.length && (
+        <button
+          onClick={() => setBatchCount((prev) => prev + 1)}
+          className="mt-4 p-2 self-center rounded bg-primary text-white hover:bg-primary/90"
+        >
+          Load More
+        </button>
+      )}
     </div>
-  );  
+  );
 };
 
 export default NoteListView;

--- a/app/lib/components/note_listview.tsx
+++ b/app/lib/components/note_listview.tsx
@@ -1,11 +1,14 @@
 import React, { useState, useEffect } from "react";
 import { Note } from "../../types";
 import { format12hourTime } from "../utils/data_conversion";
+import { Button } from "@/components/ui/button";
 
 type NoteListViewProps = {
   notes: Note[];
   onNoteSelect: (note: Note, isNewNote: boolean) => void;
 };
+
+const batch_size = 15; //can change batch loading here
 
 const extractTextFromHtml = (htmlString: string) => {
   const tempDivElement = document.createElement("div");
@@ -13,15 +16,13 @@ const extractTextFromHtml = (htmlString: string) => {
   return tempDivElement.textContent || tempDivElement.innerText || "";
 };
 
-const BATCH_SIZE = 15;
-
 const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
   const [selectedNoteId, setSelectedNoteId] = useState<string | null>(null);
   const [fresh, setFresh] = useState(true);
-  const [batchCount, setBatchCount] = useState(1);
 
-  const visibleNotes = notes.filter(note => !note.isArchived);
-  const notesToRender = visibleNotes.slice(0, BATCH_SIZE * batchCount);
+  const visibleNotes = notes.filter(note => !note.isArchived); //filter out archived notes
+  
+  const [visibleCount, setVisibleCount] =  useState(batch_size);
 
   useEffect(() => {
     if (visibleNotes.length > 0 && fresh) {
@@ -53,11 +54,15 @@ const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
     }
   };
 
+  const moreNotes = () => {
+    setVisibleCount(prev => prev + batch_size);
+  };
+
   return (
     <div id="notes-list" className="my-4 flex flex-col">
-      {notesToRender.map((note) => {
+      {visibleNotes.slice(0, visibleCount).map((note) => {
         const noteTextContent = extractTextFromHtml(note.text);
-
+  
         return (
           <div
             key={note.id}
@@ -81,16 +86,20 @@ const NoteListView: React.FC<NoteListViewProps> = ({ notes, onNoteSelect }) => {
         );
       })}
 
-      {notesToRender.length < visibleNotes.length && (
-        <button
-          onClick={() => setBatchCount((prev) => prev + 1)}
-          className="mt-4 p-2 self-center rounded bg-primary text-white hover:bg-primary/90"
-        >
-          Load More
-        </button>
+      {visibleCount < visibleNotes.length && (
+        <div className = "mt-4 flex justify-center">
+          <button  
+            onClick = {moreNotes}
+            className = "px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+          >
+            Load More Notes...
+          </button>
+        </div>
       )}
     </div>
-  );
+  );  
 };
+
+
 
 export default NoteListView;

--- a/app/lib/pages/map/page.tsx
+++ b/app/lib/pages/map/page.tsx
@@ -37,6 +37,7 @@ interface Refs {
 }
 
 const Page = () => {
+  const [visibleCount, setVisibleCount] = useState(15);
   const [notes, setNotes] = useState<Note[]>([]);
   const [filteredNotes, setFilteredNotes] = useState<Note[]>([]);
   const [activeNote, setActiveNote] = useState<Note | null>(null);
@@ -699,11 +700,8 @@ const Page = () => {
             }}
           >
             <div className="absolute flex flex-row mt-3 w-full h-10 justify-between z-10">
-              <div 
-                className="flex flex-row w-[30vw] left-0 z-10 m-5 align-center items-center">
-                {/* moving search bar*/}
-                <div className="min-w-[80px] mr-3"
-                ref={searchBarRef}>
+              <div className="flex flex-row w-[30vw] left-0 z-10 m-5 align-center items-center">
+                <div className="min-w-[80px] mr-3" ref={searchBarRef}>
                   <SearchBarMap
                     onSearch={handleSearch}
                     onNotesSearch={handleNotesSearch}
@@ -739,8 +737,7 @@ const Page = () => {
                 className="w-64 h-[300px] rounded-sm flex flex-col border border-gray-200"
               />
             ))
-          : filteredNotes.length > 0
-          ? filteredNotes.map((note) => (
+          : filteredNotes.slice(0, visibleCount).map((note) => (
               <div
                 ref={(el) => {
                   if (el) noteRefs.current[note.id] = el;
@@ -756,12 +753,12 @@ const Page = () => {
               >
                 <ClickableNote note={note} />
               </div>
-            ))
-          : [...Array(6)].map((_, index) => (
-              <Skeleton
-                key={index}
-                className="w-64 h-[300px] rounded-sm flex flex-col border border-gray-200"
-              />
+          //   ))
+          // : [...Array(6)].map((_, index) => (
+          //     <Skeleton
+          //       key={index}
+          //       className="w-64 h-[300px] rounded-sm flex flex-col border border-gray-200"
+          //     />
             ))}
         {/* <div className="flex justify-center w-full mt-4 mb-2">
           <button
@@ -778,6 +775,17 @@ const Page = () => {
             Next
           </button>
         </div> */}
+
+        {visibleCount < filteredNotes.length && (
+          <div className="col-span-full flex justify-center mt-4">
+            <button
+              onClick={() => setVisibleCount((prev) => prev + 15)}
+              className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"
+            >
+              Load More Notes...
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
1. Reference
Fixes https://github.com/oss-slu/lrda_website/issues/156

2. What Was Changed

The notes have been changed to load in 15-note batches.

3. Why Was It Changed

This was changed because a large amount of notes being loaded previously was laggy for low-end computers. Loading in batches with an option to load more will perform faster.

4. How Was It Changed

Added BATCH_SIZE constant and batchCount state.
visibleNotes limits note rendering to the current 15-batch.
Rendered a "Load More" button when there are more notes to display, that the user may optionally click.