### PR TITLE
Add Ethnographer Professor AI mentor

### DIFF
--- a/packages/web/app/lib/components/NoteEditor/NoteEditor.tsx
+++ b/packages/web/app/lib/components/NoteEditor/NoteEditor.tsx
@@ -6,7 +6,7 @@ import { CacheProvider } from '@emotion/react';
 
 const emotionCache = createCache({ key: 'css' });
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { FileX2, MessageSquare, X } from 'lucide-react';
+import { FileX2, MessageSquare, X, Sparkles } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuthStore } from '@/app/lib/stores/authStore';
 import { useShallow } from 'zustand/react/shallow';
@@ -43,6 +43,7 @@ import EditorMenuControls from '../editor_menu_controls';
 import AutoSaveIndicator from './AutoSaveIndicator';
 import PublishToggle from './NoteElements/PublishToggle';
 import { CommentSidebarPanel } from './NoteEditorComments';
+import { WritingAssistantSidebarPanel } from './WritingAssistantSidebar';
 
 type NoteEditorProps = {
   note?: Note | newNote;
@@ -73,6 +74,7 @@ export default function NoteEditor({
   const lastEditTimeRef = useRef<number>(0);
 
   // State
+  const [isWritingAssistantOpen, setIsWritingAssistantOpen] = useState<boolean>(false);
   const [isCommentSidebarOpen, setIsCommentSidebarOpen] = useState<boolean>(false);
 
   // Editor setup
@@ -430,6 +432,30 @@ export default function NoteEditor({
                     </button>
                   </>
                 )}
+
+                {!isViewingStudentNote && (
+                  <>
+                    <div className='mx-1 h-5 w-px bg-gray-300' aria-hidden='true' />
+                    <button
+                      onClick={() => setIsWritingAssistantOpen(!isWritingAssistantOpen)}
+                      className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-sm font-medium transition-colors ${
+                        isWritingAssistantOpen ?
+                          'bg-purple-100 text-purple-700 hover:bg-purple-200'
+                        : 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50'
+                      }`}
+                      aria-label={
+                        isWritingAssistantOpen ?
+                          'Close ethnographer professor'
+                        : 'Open ethnographer professor'
+                      }
+                    >
+                      {isWritingAssistantOpen ?
+                        <X className='h-4 w-4' />
+                      : <Sparkles className='h-4 w-4' />}
+                      <span>{isWritingAssistantOpen ? 'Close' : 'Professor'}</span>
+                    </button>
+                  </>
+                )}
               </div>
             </div>
 
@@ -471,6 +497,14 @@ export default function NoteEditor({
                 isInstructor={isInstructorUser}
                 canComment={canComment}
                 isOpen={isCommentSidebarOpen}
+              />
+            )}
+
+            {!isViewingStudentNote && (
+              <WritingAssistantSidebarPanel
+                noteTitle={noteState.title}
+                noteContent={noteState.editorContent}
+                isOpen={isWritingAssistantOpen}
               />
             )}
           </div>

--- a/packages/web/app/lib/components/NoteEditor/WritingAssistantSidebar.tsx
+++ b/packages/web/app/lib/components/NoteEditor/WritingAssistantSidebar.tsx
@@ -1,0 +1,205 @@
+import { useState, useRef, useEffect } from 'react';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Button } from '@/components/ui/button';
+import { Send, AlertCircle, Loader } from 'lucide-react';
+import { writingAssistantService, type WritingAssistantMessage } from '@/app/lib/services';
+import { toast } from 'sonner';
+
+interface WritingAssistantSidebarProps {
+  noteTitle: string;
+  noteContent: string;
+  isOpen: boolean;
+}
+
+export function WritingAssistantSidebarPanel({
+  noteTitle,
+  noteContent,
+  isOpen,
+}: WritingAssistantSidebarProps) {
+  const [messages, setMessages] = useState<WritingAssistantMessage[]>([]);
+  const [inputValue, setInputValue] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when new messages arrive
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSendMessage = async () => {
+    if (!inputValue.trim() || isLoading) return;
+
+    const userMessage: WritingAssistantMessage = {
+      id: Date.now().toString(),
+      role: 'user',
+      content: inputValue,
+      timestamp: new Date(),
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setInputValue('');
+    setError(null);
+    setIsLoading(true);
+
+    try {
+      const conversationHistory = messages.map(msg => ({
+        role: msg.role,
+        content: msg.content,
+      }));
+
+      const assistantResponse = await writingAssistantService.getWritingAssistance({
+        userQuery: userMessage.content,
+        noteContent,
+        noteTitle,
+        conversationHistory,
+      });
+
+      const assistantMessage: WritingAssistantMessage = {
+        id: (Date.now() + 1).toString(),
+        role: 'assistant',
+        content: assistantResponse,
+        timestamp: new Date(),
+      };
+
+      setMessages(prev => [...prev, assistantMessage]);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to get writing assistance';
+      setError(errorMessage);
+      toast('Error', {
+        description: errorMessage,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSendMessage();
+    }
+  };
+
+  const clearHistory = () => {
+    setMessages([]);
+    setError(null);
+  };
+
+  return (
+    <div
+      className={`shrink-0 overflow-hidden border-l border-gray-200 transition-[width] duration-200 ease-in-out ${
+        isOpen ? 'w-[340px]' : 'w-0 border-l-0'
+      }`}
+    >
+      <div className='flex h-full w-[340px] flex-col bg-white'>
+        {/* Header */}
+        <div className='shrink-0 border-b border-gray-200 px-4 py-3'>
+          <h3 className='text-sm font-semibold text-gray-900'>Ethnographer Professor</h3>
+          <p className='mt-1 text-xs text-gray-500'>Expert mentorship on your fieldwork</p>
+        </div>
+
+        {/* Messages area */}
+        <ScrollArea className='flex-1 px-4 py-3'>
+          <div className='space-y-4 pr-4'>
+            {messages.length === 0 && !error && (
+              <div className='text-center'>
+                <p className='text-xs text-gray-500'>
+                  Ask your ethnographer professor about your fieldwork. Get expert mentorship on
+                  methodology, ethics, and ethnographic analysis.
+                </p>
+                <div className='mt-3 space-y-2 text-xs text-gray-400'>
+                  <p className='font-medium'>Try asking:</p>
+                  <ul className='space-y-1 text-left'>
+                    <li>- Is this observation detailed enough?</li>
+                    <li>- What did I miss in this observation?</li>
+                    <li>- How can I be more reflexive here?</li>
+                    <li>- What themes do you see?</li>
+                    <li>- What follow-up questions should I ask?</li>
+                  </ul>
+                </div>
+              </div>
+            )}
+
+            {error && (
+              <div className='flex items-start gap-2 rounded-md bg-red-50 p-3'>
+                <AlertCircle className='mt-0.5 h-4 w-4 shrink-0 text-red-600' />
+                <div>
+                  <p className='text-xs font-medium text-red-900'>Error</p>
+                  <p className='text-xs text-red-700'>{error}</p>
+                </div>
+              </div>
+            )}
+
+            {messages.map(message => (
+              <div
+                key={message.id}
+                className={`flex gap-3 ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-xs rounded-lg px-3 py-2 text-sm ${
+                    message.role === 'user' ?
+                      'bg-blue-100 text-blue-900'
+                    : 'bg-gray-100 text-gray-900'
+                  }`}
+                >
+                  <p className='whitespace-pre-wrap'>{message.content}</p>
+                  <span className='text-xs opacity-60'>
+                    {message.timestamp.toLocaleTimeString([], {
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </span>
+                </div>
+              </div>
+            ))}
+
+            {isLoading && (
+              <div className='flex gap-3'>
+                <div className='flex items-center gap-2 rounded-lg bg-gray-100 px-3 py-2'>
+                  <Loader className='h-4 w-4 animate-spin text-gray-600' />
+                  <span className='text-sm text-gray-600'>Thinking...</span>
+                </div>
+              </div>
+            )}
+
+            <div ref={messagesEndRef} />
+          </div>
+        </ScrollArea>
+
+        {/* Input area */}
+        <div className='shrink-0 border-t border-gray-200 p-3'>
+          {messages.length > 0 && (
+            <button
+              onClick={clearHistory}
+              className='mb-2 w-full text-xs text-gray-500 transition-colors hover:text-gray-700'
+            >
+              Clear history
+            </button>
+          )}
+          <div className='flex gap-2'>
+            <input
+              type='text'
+              value={inputValue}
+              onChange={e => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder='Ask a question...'
+              disabled={isLoading}
+              className='flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm placeholder-gray-400 transition-colors focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none disabled:bg-gray-100 disabled:text-gray-500'
+            />
+            <Button
+              size='sm'
+              onClick={handleSendMessage}
+              disabled={isLoading || !inputValue.trim()}
+              className='shrink-0'
+              title='Send message (Enter)'
+            >
+              <Send className='h-4 w-4' />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/app/lib/services/index.ts
+++ b/packages/web/app/lib/services/index.ts
@@ -26,6 +26,10 @@ export { fetchStudents } from './instructor.service';
 // Tags service
 export { tagsService } from './tags.service';
 
+// Writing assistant service
+export { writingAssistantService } from './writing-assistant.service';
+export type { WritingAssistantMessage } from './writing-assistant.service';
+
 // Migration service -- TEMPORARY, remove after Firebase migration
 export { checkMigrationStatus } from './migration.service';
 

--- a/packages/web/app/lib/services/writing-assistant.service.ts
+++ b/packages/web/app/lib/services/writing-assistant.service.ts
@@ -1,0 +1,134 @@
+/**
+ * Ethnographer Professor Service
+ *
+ * Provides expert ethnography mentorship via a server function that calls OpenRouter.
+ * Acts as a professional ethnographer professor guiding students on research methodology.
+ * The API key stays server-side and is never exposed to the client.
+ */
+import { createServerFn } from '@tanstack/react-start';
+
+export interface WritingAssistantMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+}
+
+interface WritingAssistantInput {
+  userQuery: string;
+  noteContent: string;
+  noteTitle: string;
+  conversationHistory: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+interface OpenRouterResponse {
+  id?: string;
+  choices?: Array<{
+    message?: {
+      role?: string;
+      content?: string | null;
+    };
+    finish_reason?: string;
+  }>;
+  error?: {
+    message?: string;
+    type?: string;
+  };
+}
+
+const getWritingAssistanceOnServer = createServerFn({ method: 'POST' })
+  .inputValidator((input: WritingAssistantInput) => input)
+  .handler(async ({ data }): Promise<string> => {
+    const { userQuery, noteContent, noteTitle, conversationHistory } = data;
+
+    const OPENROUTER_API_KEY = import.meta.env.VITE_OPENROUTER_API_KEY;
+    const OPENROUTER_BASE_URL =
+      import.meta.env.VITE_OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+
+    if (!OPENROUTER_API_KEY) {
+      console.error('VITE_OPENROUTER_API_KEY is not configured');
+      throw new Error('Ethnographer Professor is not configured');
+    }
+
+    const systemPrompt = `You are an expert ethnographer professor mentoring graduate students in qualitative field research methodology. Your role is to:
+
+- Guide students on rigorous ethnographic observation and documentation
+- Help them develop critical perspectives on lived religion and cultural practices
+- Question their assumptions and encourage reflexivity about observer bias
+- Provide constructive feedback on field note quality, clarity, and detail
+- Teach proper methodology: ethical considerations, consent, positionality, and research ethics
+- Suggest follow-up questions and areas for deeper investigation
+- Help students recognize patterns, themes, and theoretical implications
+- Maintain academic rigor while supporting their learning journey
+- Challenge vague observations and encourage specificity
+- Connect their fieldwork to ethnographic theory and literature
+
+Current student note being reviewed:
+Title: "${noteTitle}"
+Content: "${noteContent}"
+
+Respond as a supportive but rigorous mentor. Ask probing questions. Point out strengths and areas for improvement. Encourage deeper thinking about methodology and ethics.`;
+
+    const messages = [
+      {
+        role: 'system' as const,
+        content: systemPrompt,
+      },
+      ...conversationHistory.map(msg => ({
+        role: msg.role as 'user' | 'assistant',
+        content: msg.content,
+      })),
+      {
+        role: 'user' as const,
+        content: userQuery,
+      },
+    ];
+
+    try {
+      const response = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${OPENROUTER_API_KEY}`,
+          'HTTP-Referer': 'http://localhost:3001',
+          'X-Title': 'Wheres Religion - Ethnographer Professor',
+        },
+        body: JSON.stringify({
+          model: 'google/gemini-2.5-flash-lite',
+          messages,
+          temperature: 0.7,
+          max_tokens: 800,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = (await response.json().catch(() => ({}))) as OpenRouterResponse;
+        const errorMessage = errorData.error?.message || 'Failed to get mentorship response';
+        throw new Error(errorMessage);
+      }
+
+      const result = (await response.json()) as OpenRouterResponse;
+
+      if (!result.choices || result.choices.length === 0) {
+        throw new Error('No response from ethnographer professor');
+      }
+
+      const assistantMessage = result.choices[0]?.message?.content;
+      if (!assistantMessage) {
+        throw new Error('Empty response from ethnographer professor');
+      }
+
+      return assistantMessage;
+    } catch (error) {
+      console.error('Ethnographer Professor error:', error);
+      throw error;
+    }
+  });
+
+async function getWritingAssistance(input: WritingAssistantInput): Promise<string> {
+  return getWritingAssistanceOnServer({ data: input });
+}
+
+export const writingAssistantService = {
+  getWritingAssistance,
+};


### PR DESCRIPTION
## Summary

- Adds an AI-powered Ethnographer Professor sidebar in the note editor for real-time academic mentorship on fieldwork methodology
- Writing assistant service calls OpenRouter (Gemini 2.5 Flash Lite) via a TanStack server function
- Tags service unchanged (uses existing API server endpoint)

Replaces #333 (rebased cleanly on main).

## Known issues to address

- `VITE_OPENROUTER_API_KEY` prefix leaks the API key to the client bundle -- should use a non-VITE env var
- `HTTP-Referer` is hardcoded to `localhost:3001`
- `OpenRouterResponse` type is duplicated (also exists in a similar form elsewhere)

## Test plan

- [ ] Open a note, click the Professor button in the toolbar
- [ ] Send a message and verify AI response renders
- [ ] Verify sidebar opens/closes correctly
- [ ] Verify tag generation still works (unchanged)
- [ ] Check browser devtools to confirm API key is not in client bundle